### PR TITLE
[RV32M1] Fix SW breakpoint with compressed instruction. Add readout CSR when save context.

### DIFF
--- a/src/target/rv32m1/rv32m1.c
+++ b/src/target/rv32m1/rv32m1.c
@@ -790,19 +790,6 @@ static int rv32m1_step(struct target *target, int current,
 				   SINGLE_STEP);
 }
 
-static int rv32m1_detect_instruction_length(target_addr_t addr, uint32_t code)
-{
-	/* Check whether instruction addr is 2 bytes aligned */
-	if (0x2 == (addr & 0x3))
-	{
-		return 2;
-	}
-	else
-	{
-		return rv32m1_chk_instruction_len(code);
-	}
-}
-
 static int rv32m1_add_breakpoint(struct target *target,
 			       struct breakpoint *breakpoint)
 {
@@ -894,7 +881,7 @@ static int rv32m1_add_breakpoint(struct target *target,
 
 		/* Detect Instruction length at breakpoint address again
 		   Some older version GDB dose not handle compressed instruction correct */
-		int instruction_len = rv32m1_detect_instruction_length(breakpoint->address, data);
+		int instruction_len = rv32m1_chk_instruction_len(data);
 
 		if (instruction_len <= 0)
 		{

--- a/src/target/rv32m1/rv32m1.h
+++ b/src/target/rv32m1/rv32m1.h
@@ -112,9 +112,9 @@ target_to_rv32m1(struct target *target)
     return (struct rv32m1_info *)target->arch_info;
 }
 
+/* RV32M1 instruction len is 2 or 4 bytes */
 static inline uint32_t rv32m1_chk_instruction_len(uint32_t instruction)
 {
-	/* RV32M1 instruction len is 2 or 4 bytes */
 	if ((instruction & 0x3) != 0x3)
 	{
 		return 2;

--- a/src/target/rv32m1/rv32m1.h
+++ b/src/target/rv32m1/rv32m1.h
@@ -41,6 +41,7 @@
  * Debug unit 0 for core 0, debug unit 1 for core 1.
  */
 #define CORE_NUM 2
+
 #define DEBUG_UNIT0_BASE        (0xF9000000)
 #define DEBUG_UNIT1_BASE        (0xF9008000)
 #define EVENT_UNIT0_BASE        (0xE0041000)
@@ -109,6 +110,21 @@ static inline struct rv32m1_info *
 target_to_rv32m1(struct target *target)
 {
     return (struct rv32m1_info *)target->arch_info;
+}
+
+static inline uint32_t rv32m1_chk_instruction_len(uint32_t instruction)
+{
+	/* RV32M1 instruction len is 2 or 4 bytes */
+	if ((instruction & 0x3) != 0x3)
+	{
+		return 2;
+	}
+	else if ((instruction & 0x1f) != 0x1f)
+	{
+		return 4;
+	}
+
+	return 0;
 }
 
 #define NO_SINGLE_STEP     0


### PR DESCRIPTION
    - When GDB request openocd to add a breakpoint and the breakpoint is
      a software breakpoint, if the breakpoint address is not aligned with
      32bits, current openocd will call to read/write memory which not
      handle the unaligned memory access. The fix will using read/write
      memory API which handle the unaligned access.

    - When GDB request openocd to add a breakpoint, some(old version) GDB will
      not handle the instruction length correctly. The fix will read the
      instruction length at breakpoint address and will try to fix the length
      of the breakpoint.

    - Add readout CSR when openocd doing saving context.